### PR TITLE
add jsk_rviz_plugin OverlayText in Rviz

### DIFF
--- a/dlo_grasp/src/dlo_grasp.py
+++ b/dlo_grasp/src/dlo_grasp.py
@@ -18,6 +18,9 @@ from geometry_msgs.msg import PoseStamped, TransformStamped
 # import tf.transformations #as tr
 import tf
 import tf2_ros
+from std_msgs.msg import ColorRGBA, Float32
+from jsk_rviz_plugins.msg import OverlayText
+
 from dlo_srv.srv import DloGraspSrv, DloGraspSrvRequest
 from dlo_srv.msg import DloInsClouds
 
@@ -84,6 +87,7 @@ class DLO_Grasp():
 
         self.dlo_graspInCam = PoseStamped()
         self.dlo_graspInCam_pub = rospy.Publisher('/dlo_graspInCam', PoseStamped, queue_size=10)
+        self.dlo_score_pub = rospy.Publisher('/dlo_grasp_score', OverlayText, queue_size=1)
 
         #=============================
         # tf StaticTransformBroadcaster  
@@ -320,6 +324,27 @@ class DLO_Grasp():
 
                 # self.vis_grasps(gg, cloud_all, 1, "Remove Collision"+str(n)+" Top "+str(1))
 
+                text = OverlayText()
+                text.width = 400
+                text.height = 80
+                text.left = 10
+                text.top = 10
+
+                text.text_size = 12
+                text.line_width = 2
+                text.font = "DejaVu Sans Mono"
+
+                text.text = """Grasp score: %f.
+                M-score: %f.
+                Manipulability score: %f.
+                Manipulability score: %f.
+                """ % (gg[id].score, gg[id].score, gg[id].score, gg[id].score)
+
+                text.fg_color = ColorRGBA(25 / 255.0, 1.0, 240.0 / 255.0, 1.0)
+                text.bg_color = ColorRGBA(0.0, 0.0, 0.0, 0.2)
+
+                self.dlo_score_pub.publish(text)
+
                 #=============================
                 # Publish dlo_graspInCam
                 # PoseStamped() cam_H_obj
@@ -468,6 +493,27 @@ class DLO_Grasp():
             #                         [score_N, width_N, height_N, depth_N, rotation_matrix_N(9), translation_N(3), object_id_N]]))
             # gg.save_npy(save_path)
 
+            text = OverlayText()
+            text.width = 400
+            text.height = 80
+            text.left = 10
+            text.top = 10
+
+            text.text_size = 12
+            text.line_width = 2
+            text.font = "DejaVu Sans Mono"
+
+            text.text = """Grasp score: %f.
+            M-score: %f.
+            Manipulability score: %f.
+            Manipulability score: %f.
+            """ % (gg[id].score, gg[id].score, gg[id].score, gg[id].score)
+
+            text.fg_color = ColorRGBA(25 / 255.0, 1.0, 240.0 / 255.0, 1.0)
+            text.bg_color = ColorRGBA(0.0, 0.0, 0.0, 0.2)
+
+            self.dlo_score_pub.publish(text)
+            
             #=============================
             # Publish dlo_graspInCam
             # PoseStamped() cam_H_obj

--- a/dlo_grasp/src/overlay_text.py
+++ b/dlo_grasp/src/overlay_text.py
@@ -1,0 +1,79 @@
+#! /usr/bin/env python3
+
+# sudo apt update
+# sudo apt install ros-noetic-jsk-rviz-plugins
+# Rviz Add jsk_rviz_plugins > OverlayText > choose rostopic
+
+import rospy
+import math
+from std_msgs.msg import ColorRGBA, Float32
+from jsk_rviz_plugins.msg import OverlayText
+
+class OverlayTextNode():
+
+    def __init__(self):
+        rospy.init_node("overlay_sample")
+
+        self.text_pub = rospy.Publisher("text_sample", OverlayText, queue_size=1)
+        self.value_pub = rospy.Publisher("value_sample", Float32, queue_size=1)
+        self.counter = 0
+        self.rate = 100
+        self.r = rospy.Rate(self.rate)
+
+    def run(self):
+        while not rospy.is_shutdown():
+            self.counter = self.counter + 1
+
+            text = OverlayText()
+
+            text.width = 400
+            text.height = 400
+            text.left = 10
+            text.top = 10
+
+            text.text_size = 12
+            text.line_width = 2
+            text.font = "DejaVu Sans Mono"
+
+            text.text = """This is OverlayText plugin.
+            The update rate is %d Hz.
+            You can write several text to show to the operators.
+            New line is supported and automatical wrapping text is also supported.
+            And you can choose font, this text is now rendered by '%s'
+
+            You can specify background color and foreground color separatelly.
+
+            Of course, the text is not needed to be fixed, see the counter: %d.
+
+            You can change text color like <span style="color: red;">this</span>
+            by using <span style="font-style: italic;">css</style>.
+            """ % (self.rate, text.font, self.counter)
+
+            text.fg_color = ColorRGBA(25 / 255.0, 1.0, 240.0 / 255.0, 1.0)
+            text.bg_color = ColorRGBA(0.0, 0.0, 0.0, 0.2)
+
+            self.text_pub.publish(text)
+            self.value_pub.publish(math.sin(self.counter * math.pi * 2 / 100))
+
+            if int(self.counter % 500) == 0:
+                rospy.logdebug('This is ROS_DEBUG.')
+            elif int(self.counter % 500) == 100:
+                rospy.loginfo('This is ROS_INFO.')
+            elif int(self.counter % 500) == 200:
+                rospy.logwarn('This is ROS_WARN.')
+            elif int(self.counter % 500) == 300:
+                rospy.logerr('This is ROS_ERROR.')
+            elif int(self.counter % 500) == 400:
+                rospy.logfatal('This is ROS_FATAL.')
+            self.r.sleep()
+
+            if rospy.is_shutdown():
+                break
+
+if __name__ == '__main__':
+    try:
+        m = OverlayTextNode()
+        m.run()
+
+    except rospy.ROSInterruptException:
+        pass


### PR DESCRIPTION
- Implementation solution for #2 :
Use jsk_rviz_plugin OverlayText to show score in Rviz 
- ToDo:
Change display text to grasp score, m-score, manip ellipsoid, ...
